### PR TITLE
Updated oh-my-zsh upgrade command

### DIFF
--- a/quickz.sh
+++ b/quickz.sh
@@ -134,7 +134,7 @@ fi
 # source ~/.zshrc
 echo -e "\nSudo access is needed to change default shell\n"
 
-if chsh -s $(which zsh) && /bin/zsh -i -c upgrade_oh_my_zsh; then
+if chsh -s $(which zsh) && /bin/zsh -i -c omz update; then
     echo -e "Installation Successful, exit terminal and enter a new session"
 else
     echo -e "Something is wrong"


### PR DESCRIPTION
As stated by oh-my-zsh "upgrade_oh_my_zsh" is deprecated. Changed command to "omz update".