### PR TITLE
Fix alias command formatting in ezshrc.zsh

### DIFF
--- a/ezshrc.zsh
+++ b/ezshrc.zsh
@@ -143,7 +143,7 @@ alias e="exit"
 alias ip="ip --color=auto"
 ## Install EZA to use this. The better ls command
 alias a='eza -la --git --colour-scale all -g --smart-group --icons always'  #the new ls; add --hyperlink if you like
-alias aa='eza -la --git --colour-scale all -g --smart-group --icons always -s modified -r'#sort by new
+alias aa='eza -la --git --colour-scale all -g --smart-group --icons always -s modified -r' #sort by new
 
 
 # CUSTOM FUNCTIONS


### PR DESCRIPTION
 Summary
- Fix alias formatting for `aa` in `ezshrc.zsh` by adding missing whitespace before the inline comment.
- Prevent `eza` from parsing malformed arguments caused by comment text being attached to the alias option.
- Keep behavior unchanged while improving reliability of the alias command. Why The previous alias line could be interpreted as an invalid argument (e.g. `-#`) depending on shell parsing, which caused:
- `eza: Unknown argument -#` This change ensures the alias is parsed correctly and runs as intended.

Changes
- `ezshrc.zsh`
  - `alias aa='... -r'#sort by new`
  - -> `alias aa='... -r' #sort by new` 

Validation
- Ran the `aa` alias after reloading shell config.
- Confirmed `eza` executes without the `Unknown argument -#` error.

The error fix and PR description were prepared with Codex 5.3.